### PR TITLE
Fix for compilation with g++ 4.8 on Ubuntu Linux

### DIFF
--- a/inc/inpaint/gradient.h
+++ b/inc/inpaint/gradient.h
@@ -7,12 +7,12 @@
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation, either version 3 of the License, or
    (at your option) any later version.
-   
+
    Inpaint is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
    GNU General Public License for more details.
-   
+
    You should have received a copy of the GNU General Public License
    along with Inpaint.  If not, see <http://www.gnu.org/licenses/>.
 */
@@ -24,7 +24,7 @@
 
 namespace Inpaint {
 
-    /** 
+    /**
         Compute the gradient at the given point using the Sobel operator.
 
         Only intended for sparse computations. For dense gradients refer to
@@ -41,13 +41,13 @@ namespace Inpaint {
     cv::Vec2f gradient(const Mat &m, int y, int x)
     {
         const uchar *rows[3] = {
-            m.ptr<uchar>(y-1),
-            m.ptr<uchar>(y),
-            m.ptr<uchar>(y+1)
+            m.template ptr<uchar>(y-1),
+            m.template ptr<uchar>(y),
+            m.template ptr<uchar>(y+1)
         };
 
-        const float gx = -1.f * rows[0][x-1] + 1.f * rows[0][x+1] + 
-                         -2.f * rows[1][x-1] + 2.f * rows[1][x+1] + 
+        const float gx = -1.f * rows[0][x-1] + 1.f * rows[0][x+1] +
+                         -2.f * rows[1][x-1] + 2.f * rows[1][x+1] +
                          -1.f * rows[2][x-1] + 1.f * rows[2][x+1];
 
         const float gy = -1.f * rows[0][x-1] + -2.f * rows[0][x] + -1.f * rows[0][x+1] +
@@ -56,8 +56,8 @@ namespace Inpaint {
         return cv::Vec2f(gx, gy);
     }
 
-    /** 
-        Compute the normalized gradient at the given point. 
+    /**
+        Compute the normalized gradient at the given point.
 
         \param m Image to operate on.
         \param y y-coordinate of target point.

--- a/inc/inpaint/stats.h
+++ b/inc/inpaint/stats.h
@@ -7,15 +7,17 @@
    it under the terms of the GNU General Public License as published by
    the Free Software Foundation, either version 3 of the License, or
    (at your option) any later version.
-   
+
    Inpaint is distributed in the hope that it will be useful,
    but WITHOUT ANY WARRANTY; without even the implied warranty of
    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
    GNU General Public License for more details.
-   
+
    You should have received a copy of the GNU General Public License
    along with Inpaint.  If not, see <http://www.gnu.org/licenses/>.
 */
+
+#include <algorithm>
 
 #ifndef INPAINT_STATS_H
 #define INPAINT_STATS_H
@@ -24,28 +26,28 @@ namespace Inpaint {
 
     /** Minimum of two */
     template<class T>
-    T minimum(T a, T b) 
+    T minimum(T a, T b)
     {
         return (std::min<T>)(a, b);
     }
 
     /** Maximum of two */
     template<class T>
-    T maximum(T a, T b) 
+    T maximum(T a, T b)
     {
         return (std::max<T>)(a, b);
     }
 
     /** Minimum of three */
     template<class T>
-    T minimum(T a, T b, T c) 
+    T minimum(T a, T b, T c)
     {
         return (std::min<T>)(a, std::min<T>(b, c));
     }
 
     /** Maximum of three */
     template<class T>
-    T maximum(T a, T b, T c) 
+    T maximum(T a, T b, T c)
     {
         return (std::max<T>)(a, std::max<T>(b, c));
     }


### PR DESCRIPTION
Fixed code for compilation with g++ 4.8 (tested on Ubuntu and Linux
Mint). See issue: https://github.com/cheind/inpaint/issues/3